### PR TITLE
fix js loading in newer versions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,23 +1,9 @@
 import os
-import shutil
+import nodes
 
-comfy_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-failfast_path = os.path.abspath(os.path.dirname(__file__))
-
-def setup_js():
-    try:
-        js_dest_path = os.path.join(comfy_path, "web", "extensions",  "failfast-comfyui-extensions")
-        js_src_path = os.path.join(failfast_path, "extensions")
-        print(js_src_path)
-        print(js_dest_path)
-        if os.path.exists(js_dest_path):
-            shutil.rmtree(js_dest_path)
-
-        shutil.copytree(js_src_path, js_dest_path)
-        
-    except Exception as e:
-        print(f"An error occurred: {e}")
-
-setup_js()
+# WEB_DIRECTORY = "./extensions"
+nodes.EXTENSION_WEB_DIRS["blibla-comfyui-extensions"] = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "extensions"
+)
 
 NODE_CLASS_MAPPINGS = {}


### PR DESCRIPTION
fixes #32

i expect the issue was to do with the rename from failfast to blibla

i just replaced how you were loading js with how impact pack does 